### PR TITLE
Add setup to build using Docker, add upx compression

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+---
+files: ^(.*\.(py|json|md|sh|yaml|cfg|txt))$
+exclude: ^(\.[^/]*cache/.*|.*/_user.py)$
+repos:
+  - repo: https://github.com/executablebooks/mdformat
+    # Do this before other tools "fixing" the line endings
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+        name: Format Markdown
+        entry: mdformat  # Executable to run, with fixed options
+        language: python
+        types: [markdown]
+        args: [--wrap, '75', --number]
+        additional_dependencies:
+          - mdformat-toc
+          - mdformat-beautysh
+          # -mdformat-shfmt
+          # -mdformat-tables
+          - mdformat-config
+          - mdformat-black
+          - mdformat-web
+          - mdformat-gfm
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: check-yaml
+        args: [--unsafe]
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-json
+      - id: mixed-line-ending
+      - id: check-builtin-literals
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-docstring-first
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      # - id: check-toml
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
+        args:
+          - --no-warnings
+          - -d
+          - '{extends: relaxed, rules: {line-length: {max: 90}}}'
+  - repo: https://github.com/lovesegfault/beautysh.git
+    rev: v6.2.1
+    hooks:
+      - id: beautysh
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        args:
+          # - --builtin=clear,rare,informal,usage,code,names,en-GB_to_en-US
+          - --builtin=clear,rare,informal,usage,code,names
+          - --ignore-words-list=hass,master
+          - --skip="./.*"
+          - --quiet-level=2

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+svgo
+/var/log/
+.git
+../.git
+package-lock.json
+../package-lock.json

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,47 @@
+## Start from the official Debian image
+# FROM debian:bullseye
+## Start from the minimal Debian image
+# FROM bitnami/minideb:bullseye
+## Start from node specific image - compatibility with old version
+# FROM node:bullseye
+# FROM node:buster
+# FROM node:stretch
+FROM node:jessie
+
+LABEL maintainer="MDW <MDW@private.fr>"
+
+## Set environment variables
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+#    && npm install -g webpack-cli \
+
+
+# Not ok on Jessie:
+#    && apt clean && apt autoremove -y \
+# --force-yes is needed for jessie
+
+RUN export DEBIAN_FRONTEND="noninteractive" \
+    && apt-get update --fix-missing \
+    && apt-get install -y --force-yes \
+        build-essential \
+        wget \
+        unzip \
+        upx \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd /tmp \
+    && wget https://github.com/bellard/quickjs/archive/refs/heads/master.zip \
+    && unzip master.zip \
+    && rm master.zip \
+    && cd quickjs-master \
+    && /bin/bash -c 'make -j "$(nproc)" install' \
+    && cd .. && rm -rf quickjs-master
+
+RUN export DEBIAN_FRONTEND="noninteractive" \
+    && npm install -g pkg \
+    && npm install -g webpack@4 webpack-cli@4
+
+#    && npm install -g webpack webpack-cli
+
+ENTRYPOINT ["/bin/bash"]

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,6 +51,7 @@ build-pkg-macos: prebuild
 	@mkdir -p ../build/svgop-pkg-macos
 	@pkg -t macos-x64 --output=../build/svgop-pkg-macos/svgop -c ./package.json ./app/svgop-pkg.js
 	@cp ../build/svgop-pkg-macos/svgop ../bin/svgop-pkg-macos/
+	@upx -9 ../bin/svgop-pkg-macos/svgop
 
 build-linux: build-pkg-linux
 
@@ -59,6 +60,7 @@ build-pkg-linux: prebuild
 	@mkdir -p ../build/svgop-pkg-linux
 	@pkg -t linux-x64 --output=../build/svgop-pkg-linux/svgop -c ./package.json ./app/svgop-pkg.js
 	@cp ../build/svgop-pkg-linux/svgop ../bin/svgop-pkg-linux/
+	@upx -9 ../bin/svgop-pkg-linux/svgop
 
 build-win: build-pkg-win64 build-pkg-win32
 
@@ -67,12 +69,14 @@ build-pkg-win32: prebuild
 	@mkdir -p ../build/svgop-pkg-win32
 	@pkg -t win-x86 --output=../build/svgop-pkg-win32/svgop.exe -c ./package.json ./app/svgop-pkg.js
 	@cp ../build/svgop-pkg-win32/svgop.exe ../bin/svgop-pkg-win32/
+	@#Fails on Jessie upx -9 ../bin/svgop-pkg-win32/svgop.exe 
 
 build-pkg-win64: prebuild
 	@echo "Building 'svgop' with pkg for Windows x64 in ./bin/svgop-pkg-win64"
 	@mkdir -p ../build/svgop-pkg-win64
 	@pkg -t win-x64 --output=../build/svgop-pkg-win64/svgop.exe -c ./package.json ./app/svgop-pkg.js
 	@cp ../build/svgop-pkg-win64/svgop.exe ../bin/svgop-pkg-win64/
+	@#Result fails (on Jessie) upx -9 ../bin/svgop-pkg-win64/svgop.exe
 
 install: build-macos
 	@echo "Installing /usr/local/bin/svgop"

--- a/src/build-with-docker.sh
+++ b/src/build-with-docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Script/commands to build using Docker
+# Note: build fails currently even in old setup,
+#       probably need to upgrade svgo
+
+# Build/update images
+docker compose build debian-base
+docker compose build build
+# Try to build all (fails to build for macos):
+docker compose run --rm build
+# Windows only:
+# docker compose run --rm build-win
+# Interactive:
+# docker compose run --rm bash

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,0 +1,35 @@
+---
+version: '3.5'
+
+services:
+  # Base image
+  debian-base:
+    build:
+      context: .
+      args:
+        - --rm
+      dockerfile: ./Dockerfile
+    working_dir: /root/workdir
+    environment:
+      DISPLAY: host.docker.internal:0.0
+      NO_AT_BRIDGE: 1
+    volumes:
+      - ..:/root/workdir
+    # command: /bin/bash
+
+  build:
+    extends: debian-base
+    working_dir: /root/workdir/src
+    command: -c "rm -rf package-lock.json ../package-lock.json .bin node_modules ../node_modules ; make -k clean all"
+
+  build-win:
+    extends: build
+    working_dir: /root/workdir/src
+    command: -c "rm -rf package-lock.json ../package-lock.json .bin node_modules ../node_modules ; make clean win"
+
+  # Run inside in interactive mode
+  #
+  #  `docker compose run --rm bash` on the CLI
+  bash:
+    extends: debian-base
+    # command: /bin/bash


### PR DESCRIPTION
This adds a Docker configuration which builds several of the targets (but not successfully for macos.

Neither the "officiel" nor the built Win64 executable work for me on Win11.

Maybe somebody could use this and work on upgrading svgo itself and build in a more recent debian environment.